### PR TITLE
Enabling dal10 as a target landing zone for Power workspace and instance

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "ibm_cloud_zone" {
   type        = string
   default     = ""
   validation {
-    condition     = contains(["syd04", "syd05", "eu-de-1", "eu-de-2", "lon04", "lon06", "wdc04", "us-east", "us-south", "dal12", "dal13", "tor01", "tok04", "osa21", "sao01", "mon01"], var.ibm_cloud_zone)
+    condition     = contains(["syd04", "syd05", "eu-de-1", "eu-de-2", "lon04", "lon06", "wdc04", "us-east", "us-south", "dal10", "dal12", "dal13", "tor01", "tok04", "osa21", "sao01", "mon01"], var.ibm_cloud_zone)
     error_message = "Only Following DC values are supported :  syd04, syd05, eu-de-1, eu-de-2, lon04, lon06, wdc04, us-east, us-south, dal10, dal12, dal13, tor01, tok04, osa21, sao01, mon01"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "ibm_cloud_zone" {
   default     = ""
   validation {
     condition     = contains(["syd04", "syd05", "eu-de-1", "eu-de-2", "lon04", "lon06", "wdc04", "us-east", "us-south", "dal12", "dal13", "tor01", "tok04", "osa21", "sao01", "mon01"], var.ibm_cloud_zone)
-    error_message = "Only Following DC values are supported :  syd04, syd05, eu-de-1, eu-de-2, lon04, lon06, wdc04, us-east, us-south, dal12, dal13, tor01, tok04, osa21, sao01, mon01"
+    error_message = "Only Following DC values are supported :  syd04, syd05, eu-de-1, eu-de-2, lon04, lon06, wdc04, us-east, us-south, dal10, dal12, dal13, tor01, tok04, osa21, sao01, mon01"
   }
 }
 


### PR DESCRIPTION
The Variable `ibm_cloud_zone` lists dal10|12|13 as options but the condition list and error messages did not include dal10.  This change adds dal10 back.

A recent announcement suggested new capacity was added to dal10 and currently is the only Dallas zone that is supported in the TransitGateway for PowerVS connection.  This may be of use to those using Dallas as a region.